### PR TITLE
診断設定に定義されている非推奨の metric ブロックを削除

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -513,12 +513,11 @@ resource "azurerm_monitor_diagnostic_setting" "diag" {
     }
   }
 
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = data.azurerm_monitor_diagnostic_categories.diag_categories[each.key].metrics
 
     content {
-      category = metric.value
-      enabled  = false
+      category = enabled_metric.value
     }
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -512,12 +512,4 @@ resource "azurerm_monitor_diagnostic_setting" "diag" {
       category = enabled_log.value
     }
   }
-
-  dynamic "enabled_metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diag_categories[each.key].metrics
-
-    content {
-      category = enabled_metric.value
-    }
-  }
 }


### PR DESCRIPTION
Fixes #11

- 非推奨の metric ブロックを削除
- enabled_metric ブロックに置き換える場合、`enabled` プロパティで無効化ができなかったため