### PR TITLE
fix: protobuf DoS脆弱性の修正

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -19,7 +19,7 @@ MarkupSafe==3.0.2
 multidict==6.4.4
 packaging==25.0
 propcache==0.3.1
-protobuf==5.29.4
+protobuf==5.31.0
 python-dateutil==2.9.0.post0
 six==1.17.0
 typing_extensions==4.13.2


### PR DESCRIPTION
Dependabotで検出されたprotobuf-pythonのDoS脆弱性を修正しました。

protobufを5.29.4から5.31.0にアップデートして、潜在的なDoS攻撃のリスクを解消しました。

Fixes #18

Generated with [Claude Code](https://claude.ai/code)