### PR TITLE
TLS/SSL証明書をAcmebotに移行

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,6 +26,8 @@ env:
   TF_VAR_location: ${{ vars.AZURE_LOCATION || 'japaneast' }}
   TF_VAR_allowed_cidr: ${{ secrets.ALLOWED_CIDR }}
   TF_VAR_custom_domain_name: ${{ secrets.CUSTOM_DOMAIN_NAME }}
+  TF_VAR_mail_address: ${{ secrets.MAIL_ADDRESS }}
+  TF_VAR_pfx_password: ${{ secrets.PFX_PASSWORD }}
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,8 +26,6 @@ env:
   TF_VAR_location: ${{ vars.AZURE_LOCATION || 'japaneast' }}
   TF_VAR_allowed_cidr: ${{ secrets.ALLOWED_CIDR }}
   TF_VAR_custom_domain_name: ${{ secrets.CUSTOM_DOMAIN_NAME }}
-  TF_VAR_mail_address: ${{ secrets.MAIL_ADDRESS }}
-  TF_VAR_pfx_password: ${{ secrets.PFX_PASSWORD }}
 
 jobs:
   terraform:

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -385,8 +385,10 @@ resource "azurerm_application_gateway" "agw" {
   }
 
   identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.id["agw"].id]
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.id["agw"].id
+    ]
   }
 
   gateway_ip_configuration {
@@ -580,22 +582,14 @@ resource "azurerm_container_app_environment" "cae" {
     maximum_count         = var.container_app_environment.workload_profile.maximum_count
   }
 
-  tags = local.tags
-}
-
-# ユーザー割り当てマネージド ID を割り当て (サポートされていないので azapi プロバイダーを使う)
-resource "azapi_update_resource" "cae_managed_identity" {
-  type        = "Microsoft.App/managedEnvironments@2025-01-01"
-  resource_id = azurerm_container_app_environment.cae.id
-
-  body = {
-    identity = {
-      type = "UserAssigned"
-      userAssignedIdentities = {
-        "${azurerm_user_assigned_identity.id["cae"].id}" = {}
-      }
-    }
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.id["cae"].id
+    ]
   }
+
+  tags = local.tags
 }
 
 # DNS サフィックス (サポートされていないので azapi プロバイダーを使う)

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -303,57 +303,6 @@ data "azurerm_key_vault_certificate" "wildcard" {
   key_vault_id = azurerm_key_vault.kv.id
 }
 
-resource "azurerm_key_vault_certificate" "cert" {
-  name         = replace(var.custom_domain_name, ".", "-")
-  key_vault_id = azurerm_key_vault.kv.id
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    lifetime_action {
-      action {
-        action_type = "AutoRenew"
-      }
-
-      trigger {
-        days_before_expiry = 30
-      }
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
-
-    x509_certificate_properties {
-      extended_key_usage = [
-        "1.3.6.1.5.5.7.3.1",
-        "1.3.6.1.5.5.7.3.2",
-      ]
-      key_usage = [
-        "digitalSignature",
-        "keyEncipherment",
-      ]
-      subject            = "CN=${var.custom_domain_name}"
-      validity_in_months = 12
-
-      subject_alternative_names {
-        dns_names = [
-          var.custom_domain_name,
-        ]
-      }
-    }
-  }
-}
-
 # ------------------------------------------------------------------------------------------------------
 # Azure DNS Zone
 # ------------------------------------------------------------------------------------------------------

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -295,12 +295,40 @@ resource "azurerm_role_assignment" "role" {
 }
 
 # ------------------------------------------------------------------------------------------------------
-# Key Vault Certificate (Self-Signed)
+# Key Vault Certificate
 # ------------------------------------------------------------------------------------------------------
-# Let's Encrypt のワイルドカード証明書を Key Vault から取得する
-data "azurerm_key_vault_certificate" "wildcard" {
-  name         = "letsencrypt-wildcard-${replace(var.custom_domain_name, ".", "-")}"
+# Acmebot で作成したワイルドカード証明書を Key Vault にインポートする
+locals {
+  pfx_file_name = "wildcard-${replace(var.custom_domain_name, ".", "-")}"
+}
+
+resource "azurerm_key_vault_certificate" "wildcard" {
+  name         = local.pfx_file_name
   key_vault_id = azurerm_key_vault.kv.id
+
+  certificate {
+    contents = filebase64("${local.pfx_file_name}.pfx")
+    password = var.pfx_password
+  }
+}
+
+# ------------------------------------------------------------------------------------------------------
+# Acmebot: Automated ACME SSL/TLS certificates issuer for Azure Key Vault
+# https://github.com/shibayan/keyvault-acmebot
+# ------------------------------------------------------------------------------------------------------
+data "azurerm_resource_group" "acmebot" {
+  name = "rg-acmebot"
+}
+
+data "azurerm_windows_function_app" "acmbot" {
+  name                = "func-acmebot${random_integer.num.result}-gbyf"
+  resource_group_name = data.azurerm_resource_group.acmebot.name
+}
+
+resource "azurerm_role_assignment" "acmebot" {
+  scope                = data.azurerm_dns_zone.zone.id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = data.azurerm_windows_function_app.acmbot.identity[0].principal_id
 }
 
 # ------------------------------------------------------------------------------------------------------
@@ -438,14 +466,14 @@ resource "azurerm_application_gateway" "agw" {
       frontend_ip_configuration_name = local.frontend_ip_configuration_name
       frontend_port_name             = "https-port"
       protocol                       = "Https"
-      ssl_certificate_name           = data.azurerm_key_vault_certificate.wildcard.name
+      ssl_certificate_name           = azurerm_key_vault_certificate.wildcard.name
       host_name                      = http_listener.value.host_name
     }
   }
 
   ssl_certificate {
-    name                = data.azurerm_key_vault_certificate.wildcard.name
-    key_vault_secret_id = data.azurerm_key_vault_certificate.wildcard.versionless_secret_id # シークレット識別子: https://{keyvault_name}.vault.azure.net/secretes/{certificate_name}/
+    name                = azurerm_key_vault_certificate.wildcard.name
+    key_vault_secret_id = azurerm_key_vault_certificate.wildcard.versionless_secret_id # シークレット識別子: https://{keyvault_name}.vault.azure.net/secretes/{certificate_name}/
   }
 
   # HTTP to HTTPS redirect rules for each site
@@ -588,7 +616,7 @@ resource "azapi_update_resource" "cae_custom_domain" {
       customDomainConfiguration = {
         certificateKeyVaultProperties = {
           identity    = azurerm_user_assigned_identity.id["cae"].id
-          keyVaultUrl = data.azurerm_key_vault_certificate.wildcard.versionless_secret_id
+          keyVaultUrl = azurerm_key_vault_certificate.wildcard.versionless_secret_id
         }
         dnsSuffix = var.custom_domain_name
       }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,6 +23,7 @@ resource "azurerm_virtual_network" "vnet" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   address_space       = var.vnet.address_space
+  dns_servers         = var.vnet.dns_servers
 
   tags = local.tags
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,14 +19,6 @@ variable "sub_domain_name" {
   default = "www"
 }
 
-variable "mail_address" {
-  type = string
-}
-
-variable "pfx_password" {
-  type = string
-}
-
 variable "vnet" {
   type = object({
     address_space = list(string)

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,6 +19,14 @@ variable "sub_domain_name" {
   default = "www"
 }
 
+variable "mail_address" {
+  type = string
+}
+
+variable "pfx_password" {
+  type = string
+}
+
 variable "vnet" {
   type = object({
     address_space = list(string)

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -62,7 +62,10 @@ variable "subnet" {
       address_prefixes                  = ["10.10.2.0/24"]
       default_outbound_access_enabled   = false
       private_endpoint_network_policies = "Disabled"
-      service_delegation                = null
+      service_delegation = {
+        name    = "Microsoft.Network/applicationGateways"
+        actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+      }
     }
     vm = {
       name                              = "vm"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -22,9 +22,11 @@ variable "sub_domain_name" {
 variable "vnet" {
   type = object({
     address_space = list(string)
+    dns_servers   = list(string)
   })
   default = {
     address_space = ["10.10.0.0/16"]
+    dns_servers   = ["10.20.4.5"] # 既定の DNS を使用する場合は空のリストを指定
   }
 }
 

--- a/scripts/create-password-protected-pfx.sh
+++ b/scripts/create-password-protected-pfx.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# パスワード付きPFXファイル作成スクリプト
+# Usage: ./create-password-protected-pfx.sh
+
+set -e
+
+# 設定
+ORIGINAL_PFX=""
+NEW_PFX=""
+TEMP_CERT="temp_cert.pem"
+TEMP_KEY="temp_key.pem"
+
+echo "=== パスワード付きPFXファイル作成開始 ==="
+
+# パスワード入力
+echo ""
+read -s -p "PFXファイルに設定するパスワードを入力してください: " PFX_PASSWORD
+echo ""
+read -s -p "パスワードを再入力してください（確認）: " PFX_PASSWORD_CONFIRM
+echo ""
+
+# パスワード確認
+if [ "$PFX_PASSWORD" != "$PFX_PASSWORD_CONFIRM" ]; then
+    echo "❌ パスワードが一致しません。スクリプトを終了します。"
+    exit 1
+fi
+
+# パスワードの長さ確認
+if [ ${#PFX_PASSWORD} -lt 8 ]; then
+    echo "❌ パスワードは8文字以上で設定してください。"
+    exit 1
+fi
+
+echo "✅ パスワードが設定されました。"
+echo ""
+
+# 1. 元のPFXファイルの存在確認
+if [ ! -f "$ORIGINAL_PFX" ]; then
+    echo "エラー: 元のPFXファイルが見つかりません: $ORIGINAL_PFX"
+    exit 1
+fi
+
+echo "1. 元のPFXファイルを確認しました: $ORIGINAL_PFX"
+
+# 2. 既存のPFXから証明書と秘密鍵を抽出（パスワードなしと仮定）
+echo "2. PFXファイルから証明書と秘密鍵を抽出中..."
+openssl pkcs12 -in "$ORIGINAL_PFX" -out "$TEMP_CERT" -nodes -passin pass:
+
+# 3. 証明書のみを抽出
+echo "3. 証明書のみを抽出中..."
+openssl pkcs12 -in "$ORIGINAL_PFX" -out temp_cert_only.pem -nokeys -passin pass:
+
+# 4. 秘密鍵のみを抽出
+echo "4. 秘密鍵のみを抽出中..."
+openssl pkcs12 -in "$ORIGINAL_PFX" -out "$TEMP_KEY" -nocerts -nodes -passin pass:
+
+# 5. パスワード付きPFXファイルを作成
+echo "5. パスワード付きPFXファイルを作成中..."
+echo "   パスワード: [設定済み]"
+openssl pkcs12 -export -out "$NEW_PFX" -inkey "$TEMP_KEY" -in temp_cert_only.pem -password pass:"$PFX_PASSWORD"
+
+# 6. 一時ファイルを削除
+echo "6. 一時ファイルをクリーンアップ中..."
+rm -f "$TEMP_CERT" "$TEMP_KEY" temp_cert_only.pem
+
+# 7. 結果確認
+if [ -f "$NEW_PFX" ]; then
+    echo "✅ パスワード付きPFXファイルが正常に作成されました: $NEW_PFX"
+    echo "   ファイルサイズ: $(ls -lh "$NEW_PFX" | awk '{print $5}')"
+else
+    echo "❌ PFXファイルの作成に失敗しました"
+    exit 1
+fi


### PR DESCRIPTION
# 概要

このPRでは、TLS/SSL証明書管理をAcmebotに移行し、Azure Container Apps環境のユーザー割り当てマネージド IDの設定を改善しました。

## 変更内容

### インフラストラクチャの変更

1. **証明書管理の改善**
   - Acmebotで作成した証明書をKey Vault証明書に保存し参照する
   - Acmebot連携のためのリソース参照とロール割り当てを追加

2. **Azure Container Apps環境の改善**
   - ユーザー割り当てマネージド IDの設定をazapiプロバイダーからネイティブTerraformに移行

3. **PFXファイル処理スクリプトの追加**
   - パスワード付きPFXファイル作成スクリプトを追加（`scripts/create-password-protected-pfx.sh`）
   - OpenSSLを使用した証明書と秘密鍵の処理

### 技術的な改善点

- **Azure Resource Manager API互換性**: azapiプロバイダーの使用を減らし、ネイティブTerraformリソースを優先
- **証明書自動化**: Acmebotによる自動証明書更新の基盤を構築
- **セキュリティ強化**: DNS Zone Contributorロールの適切な割り当て

## Mermaidダイアグラム

```mermaid
graph TB
    subgraph "証明書管理の変更"
        KV[Key Vault]
        AC[Acmebot Function App]
        DNS[Azure DNS Zone]
        
        AC -->|DNS Zone Contributor| DNS
        AC -->|証明書作成| KV
        KV -->|wildcard-*.example.com| AGW[Application Gateway]
    end
    
    subgraph "Container Apps環境の改善"
        CAE[Container Apps Environment]
        UMI[User Assigned Managed Identity]
        
        UMI -->|ネイティブTerraform| CAE
    end
    
    subgraph "変更前後の比較"
        subgraph "Before"
            KV_OLD[Key Vault<br/>letsencrypt-wildcard-*]
            CAE_OLD[CAE<br/>azapi_update_resource]
        end
        
        subgraph "After" 
            KV_NEW[Key Vault<br/>wildcard-*]
            CAE_NEW[CAE<br/>native identity block]
            AC_NEW[Acmebot<br/>自動証明書管理]
        end
        
        KV_OLD -.->|移行| KV_NEW
        CAE_OLD -.->|リファクタリング| CAE_NEW
        KV_NEW --> AC_NEW
    end
    
    style AC fill:#e1f5fe
    style CAE_NEW fill:#f3e5f5
    style KV_NEW fill:#e8f5e8
```

## テスト項目

### インフラストラクチャのテスト

- [ ] `terraform plan`でエラーが発生しないことを確認
- [ ] `terraform apply`が正常に実行されることを確認
- [ ] Key Vault証明書の取得が正常に動作することを確認
- [ ] Container Apps環境のマネージド ID設定が正しく適用されることを確認

### Acmebot連携のテスト

- [ ] Acmebot Function Appが正しく参照されることを確認
- [ ] DNS Zone ContributorロールがAcmebotに正しく割り当てられることを確認
- [ ] 証明書の自動更新が動作することを確認

### スクリプトのテスト

- [ ] `create-password-protected-pfx.sh`が正常に実行されることを確認
- [ ] パスワード付きPFXファイルが正しく作成されることを確認
- [ ] 作成されたPFXファイルが有効であることを確認

## 影響範囲

### 影響を受けるコンポーネント

- Azure Key Vault（証明書取得方法の変更）
- Azure Container Apps Environment（マネージド ID設定）
- Application Gateway（証明書参照）
- Acmebot Function App（新規連携）

### 互換性への影響

- 既存の証明書名パターンが変更されるため、移行時の調整が必要
- Acmebotが事前にデプロイされている必要がある

## チェックリスト

- [x] コードレビューを実施済み
- [x] Terraformのvalidateが通ることを確認
- [x] 関連ドキュメントの更新は不要（インフラ変更のみ）
- [x] セキュリティ要件を満たしている
- [x] 後方互換性を考慮している